### PR TITLE
fix: allow multiple digits in item positions

### DIFF
--- a/syntaxes/bitsy.tmLanguage.json
+++ b/syntaxes/bitsy.tmLanguage.json
@@ -363,7 +363,7 @@
         },
         "item_link": {
             "name": "item.link.bitsy",
-            "match": "^(ITM)\\s(.+)\\s(\\d),(\\d)",
+            "match": "^(ITM)\\s(.+)\\s(\\d+),(\\d+)",
             "captures": {
                 "1": {
                     "name": "support.function.item.bitsy"


### PR DESCRIPTION
currently items are flagged as invalid if they use double-digit positions:

![image](https://user-images.githubusercontent.com/6496840/109431613-74d45700-79d5-11eb-9a93-52b4455ec248.png)
